### PR TITLE
NFC: Only enable on real TTY (tty1)

### DIFF
--- a/heiko-cli
+++ b/heiko-cli
@@ -28,7 +28,11 @@ if __name__ == '__main__':
     cfgobj = cfg.get_all()
 
     if cfgobj["nfc"]["enable"]:
-        nfc_init()
+        # Only enable NFC on the real matomat TTY, to avoid locking conflicts
+        if os.ttyname(sys.stdout.fileno()) == "/dev/tty1":
+            nfc_init()
+        else:
+            cfgobj["nfc"]["enable"] = False
 
     # This is the login loop.
     is_logged_in = False

--- a/heiko/menu.py
+++ b/heiko/menu.py
@@ -367,6 +367,8 @@ def login(maas_builder, auth_client, cfgobj):
 
     welcome_banner()
     log("Please authenticate yourself!")
+    if cfgobj["nfc"]["enable"]:
+        log("NFC enabled")
 
     token = ""
     user = ""


### PR DESCRIPTION
Until now, logging in via SSH would mess everything up. See #46 