### PR TITLE
Replace yaml.load with yaml.safe_load

### DIFF
--- a/heiko/maassimpleconfig.py
+++ b/heiko/maassimpleconfig.py
@@ -10,7 +10,7 @@ class MaasSimpleConfig:
         self.__config = []
         with open(file_path, 'r') as stream:
             try:
-                self.__config = yaml.load(stream)
+                self.__config = yaml.safe_load(stream)
             except yaml.YAMLError as exc:
                 print(exc)
         return self


### PR DESCRIPTION
Replace `yaml.load()` with `yaml.safe_load()`. Since version 6 of PyYAML, the argument `Loader` of the `yaml.load()` method is not optional anymore. Considering that `safe_load` is recommended anyway, switch to that method.