### PR TITLE
Replace IBM Watson TTS with espeak via pyttsx3

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -9,8 +9,6 @@ maas:
 voice:
   enable: <true/false>
   path_user_greetings: ./user_greetings
-  watson_api_key: <key>
-  watson_endpoint: <endpoint>
   sounds:
     welcome: ./sound/welcome.wav
     error: ./sound/error.wav

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         'tabulate',
         'pyyaml',
         'pygame',
-        'watson_developer_cloud',
+        'pyttsx3',
     ],
 
     # extra_requires


### PR DESCRIPTION
While reconfiguration of the previously broken Matomat at K4CG we had problems to get the IBM Watson TTS back to work. The previously used URL seems to be invalid. To not have to rely on any online service for the future, replace IBM Watson with the offline TTS espeak.